### PR TITLE
disable restart of service for pip install

### DIFF
--- a/libraries/helpers_base.rb
+++ b/libraries/helpers_base.rb
@@ -126,7 +126,6 @@ HDOC
       def base_python_execute_requirements
         python_execute "#{new_resource.name}_requirements" do
           virtualenv prefix_dir
-          notifies :restart, "service[#{new_resource.service_name}]" unless new_resource.service_disabled
           new_resource.pip_install_opts.each do |attr, value|
             send(attr, value)
           end

--- a/metadata.rb
+++ b/metadata.rb
@@ -10,7 +10,7 @@ end
 if respond_to?(:source_url)
   source_url 'https://github.com/pacifica/pacifica-cookbook'
 end
-version '2.0.1'
+version '2.0.2'
 
 chef_version '>= 12'
 


### PR DESCRIPTION
### Description

This disables the restart of the service for every pip install.
When running chef continuously chef restarts the service every
time a chef run happens.

### Issues Resolved

N/A
### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
